### PR TITLE
Save WI branches on manual mode

### DIFF
--- a/client/src/app/release-step1/release-step1.component.html
+++ b/client/src/app/release-step1/release-step1.component.html
@@ -25,6 +25,11 @@
              [(ngModel)]="state.workItemId" name="workItemId" required>
     </div>
     <div class="mb-3" *ngIf="state.mode === 'manual'">
+      <label class="form-label">Work Item IDs (one per line or comma separated)</label>
+      <textarea class="form-control" rows="3" placeholder="Enter work item IDs"
+                [(ngModel)]="state.manualWorkItems" name="manualWorkItems"></textarea>
+    </div>
+    <div class="mb-3" *ngIf="state.mode === 'manual'">
       <label class="form-label">Branch Names (one per line)</label>
       <textarea class="form-control" rows="5" placeholder="Enter branch names"
                 [(ngModel)]="state.manualBranches" name="manualBranches"></textarea>

--- a/client/src/app/release-step1/release-step1.component.ts
+++ b/client/src/app/release-step1/release-step1.component.ts
@@ -25,8 +25,10 @@ export class ReleaseStep1Component {
       this.toastService.showToast('Error', 'Work item ID is required.');
       return;
     }
-    if (this.state.mode === 'manual' && !this.state.manualBranches.trim()) {
-      this.toastService.showToast('Error', 'Please enter branch names.');
+    if (this.state.mode === 'manual' &&
+        !this.state.manualBranches.trim() &&
+        !this.state.manualWorkItems.trim()) {
+      this.toastService.showToast('Error', 'Please enter branches or work item IDs.');
       return;
     }
     // Emit the collected state to the parent.


### PR DESCRIPTION
## Summary
- add `manualWorkItems` field to the release state
- support entering WI IDs when using manual mode
- store selected branches at the top of `branches` file
- new `/api/manualWorkItems` to map work item codes to branches

## Testing
- `npm test` *(fails: no test specified)*
- `npm test` in `client` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b9be11e2c8331844366cb633131b7